### PR TITLE
fix: build.sh git is_clean fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## fastgo 项目
 
-- 云原生 AI 实战营项目之一，更多精彩项目见：[云原生 AI 实战营](https://konglingfei.com/)
 - 该实战项目配套课程见： [Go 项目开发极速入门课](https://blog.csdn.net/lnxfei/category_12907774.html)
-- 本初级项目的中级版本：[miniblog](https://github.com/onexstack/miniblog)
+- 本初级项目的中/高级版本为：[miniblog](https://github.com/onexstack/miniblog)
+- 更多「云原生 AI 实战营」项目见：[云原生 AI 实战营项目介绍](https://konglingfei.com/cloudai/intro/%E4%BA%91%E5%8E%9F%E7%94%9F_AI_%E5%AE%9E%E6%88%98%E8%90%A5%E9%A1%B9%E7%9B%AE%E4%BB%8B%E7%BB%8D.html)
 
 ## fastgo 项目适宜人群
 

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ fi
 # 默认状态设为"dirty"（有未提交更改）
 GIT_TREE_STATE="dirty"
 # 使用git status检查是否有未提交的更改
-is_clean=$(shell git status --porcelain 2>/dev/null)
+is_clean=$(status --porcelain 2>/dev/null)
 # 如果is_clean为空，说明没有未提交的更改，状态设为"clean"
 if [[ -z ${is_clean} ]];then
   GIT_TREE_STATE="clean"


### PR DESCRIPTION
Removed the shell keyword and replaced it with the correct Bash command substitution syntax:
is_clean=$(git status --porcelain 2>/dev/null)